### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tmux Spotify Plugin
 
-Tmux plugin that shows the current music status for Spotify, Apple Music, or iTunes in your statusline
+Tmux plugin that shows the current music status for Spotify, Apple Music, or iTunes in your statusline.
 
 Introduces the following new status variables:
 
@@ -20,33 +20,46 @@ The following interpolations are made available for your statusline:
 
 Here's the example in `.tmux.conf`:
 
-    set -g status-right "♫ #{music_status} #{artist}: #{track} | %a %h-%d %H:%M "
+```bash
+set -g status-right "♫ #{music_status} #{artist}: #{track} | %a %h-%d %H:%M "
+```
 
 Customize the icons with:
 
-    set -g @spotify_playing_icon ">"
-    set -g @spotify_paused_icon "="
+```bash
+set -g @spotify_playing_icon ">"
+set -g @spotify_paused_icon "="
 
-    # optional: defaults to `paused_icon`
-    set -g @spotify_stopped_icon "X"
-
-By default Spotify is used as the media source.  iTunes or Apple Music can be used by setting `MUSIC_APP` in
-your `bashrc`
+# optional: defaults to `paused_icon`
+set -g @spotify_stopped_icon "X"
 ```
+
+By default, Spotify is used as the media source. iTunes or Apple Music can be used by setting `MUSIC_APP` in your `bashrc`:
+
+```bash
 # set tmux-spotify to use Apple Music instead of Spotify
 export MUSIC_APP="Music"
 ```
-set `MUSIC_APP` to `iTunes` instead on macOS<Catalina
+
+Set `MUSIC_APP` to `iTunes` instead on macOS Catalina.
+
+If the `status-right` overflows when the music title is too long, you can increase the `status-right-length` by using the following line in `.tmux.conf`:
+
+```bash
+set -g status-right-length 70
+```
 
 ### Screenshots
 
-![status](/screenshots/spotify-status.png)<br/>
+![status](/screenshots/spotify-status.png)
 
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
-Add plugin to the list of TPM plugins in `.tmux.conf`:
+Add the plugin to the list of TPM plugins in `.tmux.conf`:
 
-    set -g @plugin 'robhurring/tmux-spotify'
+```bash
+set -g @plugin 'robhurring/tmux-spotify'
+```
 
 Hit `prefix + I` to fetch the plugin and source it.
 
@@ -54,14 +67,20 @@ Hit `prefix + I` to fetch the plugin and source it.
 
 Clone the repo:
 
-    $ git clone https://github.com/robhurring/tmux-spotify ~/clone/path
+```bash
+$ git clone https://github.com/robhurring/tmux-spotify ~/clone/path
+```
 
 Add this line to the bottom of `.tmux.conf`:
 
-    run-shell ~/clone/path/music.tmux
+```bash
+run-shell ~/clone/path/music.tmux
+```
 
-Reload TMUX environment:
+Reload the TMUX environment:
 
-    # type this in terminal
-    $ tmux source-file ~/.tmux.conf
+```bash
+# type this in the terminal
+$ tmux source-file ~/.tmux.conf
+```
 


### PR DESCRIPTION
Overflowing right status due to long music title can be fixed by increasing the right status length, this can be helpful in README.md for people who are new to tmux.

I've added steps to fix this in readme and also corrected some punctuation and grammar, please correct me if I'm doing anything wrong.

fixes #10 